### PR TITLE
Don't use protocol relative URL's

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function analyticsTrackingCode(config) {
     "(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){",
     "(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),",
     "m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)",
-    "})(window,document,'script','//www.google-analytics.com/analytics.js','" + config.globalVariable + "');",
+    "})(window,document,'script','https://www.google-analytics.com/analytics.js','" + config.globalVariable + "');",
     "",
     "" + config.globalVariable + "('create', '" + config.webPropertyId + "', " + gaConfig + ");",
     "</script>"


### PR DESCRIPTION
Cordova doesn't support protocol relative URL's, and instead resolves this to `file://` (I know right?). Also, you should always use `https://` when `https://` exists which is does in this case.