### PR TITLE
Call manually pageviewToGA()

### DIFF
--- a/app/mixins/google-pageview.js
+++ b/app/mixins/google-pageview.js
@@ -2,7 +2,11 @@ import Ember from 'ember';
 import ENV from '../config/environment';
 
 export default Ember.Mixin.create({
-  pageviewToGA: function() {
+
+  pageviewToGA: function(page, title) {
+    var page = page ? page : this.get('url');
+    var title = title ? title : this.get('url');
+
     if (Ember.get(ENV, 'googleAnalytics.webPropertyId') != null) {
       var trackerType = Ember.getWithDefault(ENV, 'googleAnalytics.tracker', 'analytics.js');
 
@@ -10,12 +14,13 @@ export default Ember.Mixin.create({
         var globalVariable = Ember.getWithDefault(ENV, 'googleAnalytics.globalVariable', 'ga');
 
         window[globalVariable]('send', 'pageview', {
-          page: this.get('url'),
-          title: this.get('url')
+          page: page,
+          title: title 
         });
       } else if (trackerType === 'ga.js') {
         window._gaq.push(['_trackPageview']);
       }
     }
   }.on('didTransition')
+
 });

--- a/app/mixins/google-pageview.js
+++ b/app/mixins/google-pageview.js
@@ -15,7 +15,7 @@ export default Ember.Mixin.create({
 
         window[globalVariable]('send', 'pageview', {
           page: page,
-          title: title 
+          title: title
         });
       } else if (trackerType === 'ga.js') {
         window._gaq.push(['_trackPageview']);


### PR DESCRIPTION
This change allows you to send a page view with a custom url and title.

Currently I'm using it with hash fragments only, but probably its useful if you want to track query parameters too.

Usage example in a view:

```js
import googlePageview from '../mixins/google-pageview';                          
var ga = Ember.Object.extend(googlePageview).create();

click: function() {
  // some logic
  ga.pageviewToGA(page_with_hash, updated_title);
}
```
