### PR TITLE
Added callback function to send additional data before pageview is sent

### DIFF
--- a/app/mixins/google-pageview.js
+++ b/app/mixins/google-pageview.js
@@ -2,6 +2,9 @@ import Ember from 'ember';
 import ENV from '../config/environment';
 
 export default Ember.Mixin.create({
+  beforePageviewToGA: function (ga) {
+
+  },
 
   pageviewToGA: function(page, title) {
     var page = page ? page : this.get('url');
@@ -12,6 +15,8 @@ export default Ember.Mixin.create({
 
       if (trackerType === 'analytics.js') {
         var globalVariable = Ember.getWithDefault(ENV, 'googleAnalytics.globalVariable', 'ga');
+
+	this.beforePageviewToGA(window[globalVariable]);
 
         window[globalVariable]('send', 'pageview', {
           page: page,

--- a/app/mixins/google-pageview.js
+++ b/app/mixins/google-pageview.js
@@ -16,7 +16,7 @@ export default Ember.Mixin.create({
       if (trackerType === 'analytics.js') {
         var globalVariable = Ember.getWithDefault(ENV, 'googleAnalytics.globalVariable', 'ga');
 
-	this.beforePageviewToGA(window[globalVariable]);
+        this.beforePageviewToGA(window[globalVariable]);
 
         window[globalVariable]('send', 'pageview', {
           page: page,


### PR DESCRIPTION
In our application we want to track a number of custom dimensions in addition to the default statistics logged by Google. This requires us to call `ga('set', 'dimensionName', 'value');` before `ga('send', 'pageview');` is called (source: https://support.google.com/analytics/answer/2709828). To this end, I've added a custom function to the mixin which is called prior to sending the pageview, with a default empty implementation.
