### PR TITLE
Feature/remove prototype extensions

### DIFF
--- a/app/mixins/google-pageview.js
+++ b/app/mixins/google-pageview.js
@@ -3,7 +3,7 @@ import ENV from '../config/environment';
 
 export default Ember.Mixin.create({
 
-  pageviewToGA: function(page, title) {
+  pageviewToGA: Ember.on('didTransition', function(page, title) {
     var page = page ? page : this.get('url');
     var title = title ? title : this.get('url');
 
@@ -21,6 +21,6 @@ export default Ember.Mixin.create({
         window._gaq.push(['_trackPageview']);
       }
     }
-  }.on('didTransition')
+  })
 
 });

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ember-cli-qunit": "0.3.1",
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.12",
+    "ember-disable-prototype-extensions": "^1.0.1",
     "ember-export-application-global": "^1.0.0",
     "express": "^4.8.5",
     "glob": "^4.0.5"


### PR DESCRIPTION
This PR removes the reliance on prototype extensions as is now considered best practice across the Ember ecosystem ([see here](https://github.com/emberjs/guides/pull/110)).
