### PR TITLE
set url using ENV baseURL

### DIFF
--- a/app/mixins/google-pageview.js
+++ b/app/mixins/google-pageview.js
@@ -8,6 +8,7 @@ export default Ember.Mixin.create({
 
   pageviewToGA: Ember.on('didTransition', function(page, title) {
     var page = page ? page : this.get('url');
+    page = Ember.getWithDefault(ENV, 'baseURL', '') + page;
     var title = title ? title : this.get('url');
 
     if (Ember.get(ENV, 'googleAnalytics.webPropertyId') != null) {


### PR DESCRIPTION
Analytics doesn't recognize the baseURL set in ENV. Changing the page variable to include the baseURL when it's set.
